### PR TITLE
cleans up inodes and unattended-upgrade bugs

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,5 @@ galaxy_info:
   galaxy_tags:
     - provisioning
     - ssh
-dependencies: []
+dependencies:
+  - jnv.unattended-upgrades

--- a/tasks/inode-fix.yml
+++ b/tasks/inode-fix.yml
@@ -1,0 +1,3 @@
+---
+- name: Cleans up apt cache to free up inodes
+  command: apt-get clean

--- a/tasks/jnv.unattended-updates.yml
+++ b/tasks/jnv.unattended-updates.yml
@@ -1,0 +1,5 @@
+---
+- name: remove 20auto-upgrades.ucf-dist if present. Workaround for https://github.com/jnv/ansible-role-unattended-upgrades/issues/10
+  file: path=/etc/apt/apt.conf.d/20auto-upgrades.ucf-dist state=absent
+- name: Force install of update-notifier-common (copied over from previous role)
+  apt: pkg=update-notifier-common state=latest force=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,12 @@
   with_file:
     - "{{ deployers_path }}"
 
+- name: Include tasks to fix jnv.unattended-updates
+  include: jnv.unattended-updates.yml
+
+- name: Free up inodes
+  include: inode-fix.yml
+
 - name: Update Apt cache (equivalent to apt-get update)
   apt: update_cache=yes
 


### PR DESCRIPTION
- Clears out all the temp files so we don't run out of inodes on the
  server. We should install https://newrelic.com/plugins/foild/344 to
  monitor inodes instead of checking every 2 weeks
- Cleans up cruft left by jnv.unattended-updates role here
  https://github.com/jnv/ansible-role-unattended-upgrades/issues/10. We
  should do a PR but jnv wants proof - using docker to prove it would be a
  good excercise here
