### PR TITLE
restart rsyslog after log rotation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 deployers_path: "~/"
+common_restart_rsyslog: true

--- a/templates/logrotate.nginx
+++ b/templates/logrotate.nginx
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 /var/log/nginx/*.log {
   daily
   missingok
@@ -9,5 +10,6 @@
   sharedscripts
   postrotate
     [ -f /var/run/nginx.pid ] && kill -USR1 $(cat /var/run/nginx.pid)
+    {% if common_restart_rsyslog %} reload rsyslog >/dev/null 2>&1 || true {% endif %}
   endscript
 }

--- a/templates/logrotate.nginx
+++ b/templates/logrotate.nginx
@@ -10,6 +10,10 @@
   sharedscripts
   postrotate
     [ -f /var/run/nginx.pid ] && kill -USR1 $(cat /var/run/nginx.pid)
-    {% if common_restart_rsyslog %} reload rsyslog >/dev/null 2>&1 || true {% endif %}
+    {% if common_restart_rsyslog %}
+    service rsyslog stop
+    rm /var/spool/rsyslog/imfile-state*
+    service rsyslog start
+    {% endif %}
   endscript
 }

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -10,7 +10,9 @@
   copytruncate
   {% if common_restart_rsyslog %}
   postrotate
-    reload rsyslog >/dev/null 2>&1 || true
+    service rsyslog stop
+    rm /var/spool/rsyslog/imfile-state*
+    service rsyslog start
   endscript
   {% endif %}
 }

--- a/templates/logrotate.rails
+++ b/templates/logrotate.rails
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 /srv/**/log/*.log {
   su root root
   daily
@@ -7,4 +8,9 @@
   notifempty
   delaycompress
   copytruncate
+  {% if common_restart_rsyslog %}
+  postrotate
+    reload rsyslog >/dev/null 2>&1 || true
+  endscript
+  {% endif %}
 }


### PR DESCRIPTION
- possible fix for logs no longer being shipped after a rotation (Loggly recommended way of fixing the rsyslog/rotation issue)

See also:
- http://kb.monitorware.com/rsyslog-imfile-module-breaks-when-files-are-truncated-t10891.html
- https://www.loggly.com/docs/log-rotate/
