### PR TITLE
drop runit

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,6 @@
     - gt5
     - nodejs
     - nodejs-legacy
-    - runit
     - python-pycurl
     - unzip
     - ack-grep


### PR DESCRIPTION
🐘 
- Since this role is only meant to be used on Ubuntu 16.04 (xenial) and
  it uses systemd to manage processes, we don't need runit anymore

- Potential side effect is extra hard drive space available on the
  server so people may have the ability to store more cat videos.
  Watching said cat videos could lead to a decrease in productivity.