### PR TITLE
Fixes script on provisioning

### DIFF
--- a/tasks/jnv.unattended-updates.yml
+++ b/tasks/jnv.unattended-updates.yml
@@ -12,6 +12,8 @@
 - name: get list of nginx packages
   shell: "apt-mark showauto | grep nginx"
   register: nginx_packages
+  failed_when: >
+    nginx_packages.rc != 0 and nginx_packages.stderr != ""
 - name: lock list of nginx packages at current version
   command: "apt-mark hold {{ item }}"
   with_items: "{{ nginx_packages.stdout_lines }}"

--- a/tasks/jnv.unattended-updates.yml
+++ b/tasks/jnv.unattended-updates.yml
@@ -6,6 +6,8 @@
 - name: get list of ruby packages
   shell: "apt-mark showauto | grep ruby"
   register: ruby_packages
+  failed_when: >
+    ruby_packages.rc != 0 and ruby_packages.stderr != ""
 - name: lock list of ruby packages at current version
   command: "apt-mark hold {{ item }}"
   with_items: "{{ ruby_packages.stdout_lines }}"


### PR DESCRIPTION
🐘 This task is used on provisioning, and if it can't find any nginx (which
it won't on first provision, grep will throw an error which causes the
ansible script to fail. The standard error it throws is "" though, and
rc is 1. I only want errors to be thrown by the tasks if rc is not 0 (0
is non-error), and the stderr is not "". That way, other errors will get
triggered, but the issue of finding nothing won't break the script.