### PR TITLE
VSTS-105 - Server Rebuild | DataDog

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,26 @@
     name: Datadog.datadog
   vars:
     datadog_api_key: "{{ secrets.datadog_api_key }}"
+    datadog_config:
+      apm_config:
+        enabled: true
+        max_traces_per_second: 10
+        ignore_resources:
+          - 'GET /health_check'
+      process_config:
+        enabled: 'true'
+      force_tls_12: true
+      collect_ec2_tags: true
+  tags:
+    - datadog
+
+- name: Configure DataDog Disk Check Whitelist
+  template:
+    src: disk.yaml.j2
+    dest: /etc/datadog-agent/conf.d/disk.d/conf.yaml
+    owner: dd-agent
+    group: dd-agent
+    mode: 0644
   tags:
     - datadog
 

--- a/templates/disk.yaml.j2
+++ b/templates/disk.yaml.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+init_config:
+
+instances:
+  - use_mount: false
+    file_system_whitelist:
+      - ext[34]$
+    tag_by_filesystem: true


### PR DESCRIPTION
:elephant:

* Set sane datadog configuration values to utilize APM and
  process monitors.
* Setup disk whitelists so that Datadog doesn't send data about system managed disks (i.e. snap images [1]).

[1]: https://docs.datadoghq.com/integrations/disk/
SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/105