### PR TITLE
ADO-3600 - SSH Authorized Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ deployer_home_dir: "/srv/{{ deployer }}"
 root_user: <root_user_name> # optional
 deployers_path: <path_to_deployers_ssh_public_key_template>
 sudoers_path: <path_to_sudoers_ssh_public_key_template> # defaults to deployers_path
+ssh_key_options: 'no-pty' # defaults to 'no-X11-forwarding,no-port-forwarding'. See https://man.openbsd.org/OpenBSD-current/man8/sshd.8#AUTHORIZED_KEYS_FILE_FORMAT.
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 deployers_path: "~/"
 root_user: "{{ ansible_ssh_user }}"
 sudoers_path: "{{ deployers_path }}"
+ssh_key_options: "no-X11-forwarding,no-port-forwarding"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,19 @@
 
 - name: Set up authorized_keys for admin user
   authorized_key:
+    exclusive: yes
+    key: "{{ lookup('file', sudoers_path) }}"
+    key_options: "{{ ssh_key_options }}"
+    state: present
     user: "{{ root_user }}"
-    key: "{{ item }}"
-  with_file:
-    - "{{ sudoers_path }}"
 
 - name: Set up authorized_keys for app deployment user
   authorized_key:
+    exclusive: yes
+    key: "{{ lookup('file', deployers_path) }}"
+    key_options: "{{ ssh_key_options }}"
+    state: present
     user: "{{ deployer }}"
-    key: "{{ item }}"
-  with_file:
-    - "{{ deployers_path }}"
 
 - name: Include tasks to fix jnv.unattended-updates
   include: jnv.unattended-updates.yml


### PR DESCRIPTION
* Use the `lookup` function to get the content of the key file
  when using the `authorized_key` module. This module is not
  loop-aware, so it's best to specify all keys at once [1].
* Use the `exclusive` flag to ensure that only specified
  keys are granted access.
* Allow the passing of the `ssh_key_options` variable so that
  SSH access can be restricted.

[1]: https://docs.ansible.com/ansible/latest/modules/authorized_key_module.html
[2]: https://man.openbsd.org/OpenBSD-current/man8/sshd.8#AUTHORIZED_KEYS_FILE_FORMAT
SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/3600